### PR TITLE
Carry out deduplication with DeDup instead of PicardMarkDuplicates

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,3 +1,3 @@
 clean_reads_dir: "/data/biol-silvereye/ball6625/nf-polish/museum-results/05.low_complex"
-samples: "/data/biol-silvereye/ball6625/map-pipeline/samples.txt"
+samples: "/data/biol-silvereye/ball6625/map-pipeline/museum-samples.txt"
 reference_genome: "/data/biol-silvereye/ball6625/ref-genome/Zlat_2_Tgutt_ZW.fasta"

--- a/environment.yaml
+++ b/environment.yaml
@@ -8,3 +8,4 @@ dependencies:
   - snakemake
   - snakemake-executor-plugin-slurm
   - conda
+  - dedup=0.12.8

--- a/envs/dedup.yaml
+++ b/envs/dedup.yaml
@@ -1,0 +1,5 @@
+name: dedup
+channels:
+  - bioconda
+dependencies:
+  - dedup

--- a/envs/dedup.yaml
+++ b/envs/dedup.yaml
@@ -1,5 +1,5 @@
-name: dedup
 channels:
   - bioconda
+  - conda-forge
 dependencies:
-  - dedup
+  - dedup = 0.12.8

--- a/run.sh
+++ b/run.sh
@@ -2,13 +2,13 @@
 #SBATCH --job-name=snakemake
 #SBATCH --partition=short
 #SBATCH --time=12:00:00
-#SBATCH --output=slurm-logs/sbatch_%j.log
-#SBATCH --error=slurm-logs/sbatch_%j.error
+#SBATCH --output=slurm-logs1/sbatch_%j.log
+#SBATCH --error=slurm-logs1/sbatch_%j.error
 
 # Load necessary modules
 ml Mamba/23.11.0-0
 
-# Load environment with snakemake and new conda installed
+# Load environment with snakemake, new conda and dedup
 source activate /data/biol-silvereye/ball6625/map-pipeline/snakemake-env
 conda config --set channel_priority strict
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -28,8 +28,8 @@ rule all:
         expand("results/dedup/{sample}.bam", sample=SAMPLES),                   # deduplicated bams
         expand("results/dedup/{sample}.stats", sample=SAMPLES),                 # mapping stats
         expand("results/dedup/{sample}.depth", sample=SAMPLES),                 # depth stats
-        "results/mapping_summary.txt"                                           # summary of stats
-        "results/avg_depth.txt"                                                 # average depth
+        "results/mapping_summary.txt",                                           # summary of stats
+        "results/avg_depth.txt",                                                 # average depth
         expand("results/mapdamage/{sample}/Runtime_log.txt", sample=SAMPLES)    # mapdamage results
 
 localrules:

--- a/workflow/rules/map.smk
+++ b/workflow/rules/map.smk
@@ -18,28 +18,16 @@ rule bwa_map:
         reads=lambda wildcards: os.path.join(config["clean_reads_dir"], wildcards.sample, f"{wildcards.sample}_U.fastq.gz"),
         idx=multiext(config["reference_genome"], ".amb", ".ann", ".bwt.2bit.64", ".pac", ".0123")
     output:
-        "results/mapped/{sample}.bam"
+        "results/sorted/{sample}.bam"
     log:
         "results/logs/bwa_map/{sample}.log"
+    params:
+        sort="samtools"
     threads: 8
     resources:
         mem="32GB"
     wrapper:
         "v5.8.0/bio/bwa-mem2/mem"
-
-# Sort reads
-rule samtools_sort:
-    input:
-        "results/mapped/{sample}.bam"
-    output:
-        "results/sorted/{sample}.bam"
-    log:
-        "results/logs/samtools_sort/{sample}.log"
-    threads: 4
-    resources:
-        mem="100GB"
-    wrapper:
-        "v5.8.0/bio/samtools/sort"
 
 # Index the sorted bam file
 rule samtools_index:


### PR DESCRIPTION
Use the software [DeDup](https://github.com/apeltzer/DeDup) instead of Picard to remove duplicates. DeDup is specialised for merged paired-end reads and so is a better choice for museum reads. This modification should avoid throwing out unecessary data, since DeDup looks at both the 3' and 5' ends of reads when deciding whether something is a duplicate. 